### PR TITLE
Prevent double rounding of Toggl imported minutes

### DIFF
--- a/Time Importer/Toggl.grandtotalplugin/index.js
+++ b/Time Importer/Toggl.grandtotalplugin/index.js
@@ -109,7 +109,7 @@ function timedEntries()
 					aItemResult["project"] = aItems[aEntry]["project"];
 				if (aItems[aEntry]["task"])
 					aItemResult["category"] = aItems[aEntry]["task"];
-				aItemResult["minutes"] = Math.round(aItems[aEntry]["dur"] / 60000);
+				aItemResult["minutes"] = aItems[aEntry]["dur"] / 60000;
 				aItemResult["notes"] = aItems[aEntry]["description"];
 				aItemResult["user"] = aItems[aEntry]["user"] + " ("+ aWorkspaceName +")";
 				aItemResult["label"] = aItems[aEntry]["tags"].join(", ");


### PR DESCRIPTION
In cases where a Toggl entry is between 0 and 30 seconds over a multiple of the `roundTo` value, GrandTotal would round down instead of up, as it first rounded to the nearest whole minute value.

Toggl _always_ rounds up, so this PR matches GrandTotal to Toggl's behavior.

I tested with 0 as the `roundTo` value and all still seems to work, but if `aMinutes` must always be an integer then I can move the `if (aMinutes > 0 && roundTo > 0)` conditional up to the top where `aItemResult["minutes"]` is first set.
